### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ https://github.com/cplusplus/LWG is the repository for the C++ Standards Committ
 Library Working Group issues lists files. 
 
 For the most recent draft of the lists generated from these files,
-see http://cplusplus.github.com/LWG/lwg-active.html 
+see http://cplusplus.github.io/LWG/lwg-active.html 
 
 For the official versions of these lists,
 see http://www.open-std.org/jtc1/sc22/wg21/


### PR DESCRIPTION
fixed the broken link by updating the URL from .com to .io